### PR TITLE
extend the journald.conf template to cover all parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,21 @@ Requirements
 Role Variables
 --------------
 
-Role variables include all supported journald parameters as documented in detail at the [freedesktop.org website](https://www.freedesktop.org/software/systemd/man/journald.conf.html#).
+Role variables include all supported journald parameters as documented in
 
-Each variable has the `systemd_journald_` prefix, and is named for the parameter.  For example, the `MaxRetentionSec=` parameter maps to the `systemd_journald_maxretensionsec` role variable.
+detail at the freedesktop.org website.
 
-Because every parameter has a default, journald.conf starts completely commented out, until you choose to override a parameter default.
+Each variable has the `systemd_journald_` prefix, and is named for the
+
+parameter.  For example, the `MaxRetentionSec=` parameter maps to the
+
+`systemd_journald_maxretensionsec` role variable.
+
+Because every parameter of journald has an application default value,
+
+`journald.conf` starts completely commented out, until you choose to override
+
+a parameter default.
 
 ```yml
 systemd_journald_maxretentionsec: '1month'
@@ -108,6 +118,11 @@ License
 
 MIT
 
+
+Resources
+---------
+
+[freedesktop.org documentation for journald](https://www.freedesktop.org/software/systemd/man/journald.conf.html#)
 
 Author Information
 ------------------

--- a/README.md
+++ b/README.md
@@ -30,8 +30,14 @@ Requirements
 Role Variables
 --------------
 
+Role variables include all supported journald parameters as documented in detail at the [freedesktop.org website](https://www.freedesktop.org/software/systemd/man/journald.conf.html#).
+
+Each variable has the `systemd_journald_` prefix, and is named for the parameter.  For example, the `MaxRetentionSec=` parameter maps to the `systemd_journald_maxretensionsec` role variable.
+
+Because every parameter has a default, journald.conf starts completely commented out, until you choose to override a parameter default.
+
 ```yml
-systemd_journald_max_retention: '1month'
+systemd_journald_maxretentionsec: '1month'
 ```
 
 

--- a/templates/journald.conf.j2
+++ b/templates/journald.conf.j2
@@ -1,48 +1,169 @@
 #  This file is part of systemd.
 #
-#  systemd is free software; you can redistribute it and/or modify it
-#  under the terms of the GNU Lesser General Public License as published by
-#  the Free Software Foundation; either version 2.1 of the License, or
-#  (at your option) any later version.
+#  systemd is free software; you can redistribute it and/or modify it under the
+#  terms of the GNU Lesser General Public License as published by the Free
+#  Software Foundation; either version 2.1 of the License, or (at your option)
+#  any later version.
 #
-# Entries in this file show the compile time defaults.
-# You can change settings by editing this file.
-# Defaults can be restored by simply deleting this file.
+# Entries in this file show the compile time defaults. Local configuration
+# should be created by either modifying this file, or by creating "drop-ins" in
+# the system.conf.d/ subdirectory. The latter is generally recommended.
+# Defaults can be restored by simply deleting this file and all drop-ins.
+#
+# Use 'systemd-analyze cat-config systemd/journald.conf' to display the full config.
 #
 # See journald.conf(5) for details.
 
+# {{ ansible_managed }}
+
+
 [Journal]
+{% if systemd_journald_storage is defined %}
+Storage={{ systemd_journald_storage }}
+{% else %}
 #Storage=auto
+{% endif %}
+{% if systemd_journald_compress is defined %}
+Compress={{ systemd_journald_compress }}
+{% else %}
 #Compress=yes
+{% endif %}
+{% if systemd_journald_seal is defined %}
+Seal={{ systemd_journald_seal }}
+{% else %}
 #Seal=yes
+{% endif %}
+{% if systemd_journald_splitmode is defined %}
+SplitMode={{ systemd_journald_splitmode }}
+{% else %}
 #SplitMode=uid
+{% endif $}
+{% if systemd_journald_syncintervalsec is defined %}
+SyncIntervalSec={{ systemd_journald_syncintervalsec }}
+{% else %}
 #SyncIntervalSec=5m
+{% endif $}
+{% if systemd_journald_ratelimitintervalsec is defined %}
+RateLimitIntervalSec={{ systemd_journald_ratelimitintervalsec }}
+{% else %}
 #RateLimitIntervalSec=30s
+{% endif $}
+{% if systemd_journald_ratelimitburst is defined %}
+RateLimitBurst={{ systemd_journald_ratelimitburst }}
+{% else %}
 #RateLimitBurst=10000
+{% endif $}
+{% if systemd_journald_systemmaxuse is defined %}
+SystemMaxUse={{ systemd_journald_systemmaxuse }}
+{% else %}
 #SystemMaxUse=
+{% endif $}
+{% if systemd_journald_systemkeepfree is defined %}
+SystemKeepFree={{ systemd_journald_systemkeepfree }}
+{% else %}
 #SystemKeepFree=
+{% endif $}
+{% if systemd_journald_systemmaxfilesize is defined %}
+SystemMaxFileSize={{ systemd_journald_systemmaxfilesize }}
+{% else %}
 #SystemMaxFileSize=
+{% endif $}
+{% if systemd_journald_systemmaxfiles is defined %}
+SystemMaxFiles={{ systemd_journald_systemmaxfiles }}
+{% else %}
 #SystemMaxFiles=100
+{% endif $}
+{% if systemd_journald_runtimemaxuse is defined %}
+RuntimeMaxUse={{ systemd_journald_runtimemaxuse }}
+{% else %}
 #RuntimeMaxUse=
+{% endif $}
+{% if systemd_journald_runtimekeepfree is defined %}
+RuntimeKeepFree={{ systemd_journald_runtimekeepfree }}
+{% else %}
 #RuntimeKeepFree=
+{% endif $}
+{% if systemd_journald_runtimemaxfilesize is defined %}
+RuntimeMaxFileSize={{ systemd_journald_runtimemaxfilesize }}
+{% else %}
 #RuntimeMaxFileSize=
+{% endif $}
+{% if systemd_journald_runtimemaxfiles is defined %}
+RuntimeMaxFiles={{ systemd_journald_runtimemaxfiles }}
+{% else %}
 #RuntimeMaxFiles=100
-{% if systemd_journald_max_retention is defined %}
-MaxRetentionSec={{ systemd_journald_max_retention }}
+{% if systemd_journald_maxretentionsec is defined %}
+MaxRetentionSec={{ systemd_journald_maxretentionsec }}
 {% else %}
 #MaxRetentionSec=
 {% endif %}
+{% if systemd_journald_maxfilesec is defined %}
+MaxFileSec={{ systemd_journald_maxfilesec }}
+{% else %}
 #MaxFileSec=1month
+{% endif $}
+{% if systemd_journald_forwardtosyslog is defined %}
+ForwardToSyslog={{ systemd_journald_ForwardToSyslog }}
+{% else %}
 #ForwardToSyslog=no
+{% endif $}
+{% if systemd_journald_forwardtokmsg is defined %}
+ForwardToKMsg={{ systemd_journald_forwardtokmsg }}
+{% else %}
 #ForwardToKMsg=no
+{% endif $}
+{% if systemd_journald_forwardtoconsole is defined %}
+ForwardToConsole={{ systemd_journald_forwardtoconsole }}
+{% else %}
 #ForwardToConsole=no
+{% endif $}
+{% if systemd_journald_forwardtowall is defined %}
+ForwardToWall={{ systemd_journald_forwardtowall }}
+{% else %}
 #ForwardToWall=yes
+{% endif $}
+{% if systemd_journald_ttypath is defined %}
+TTYPath={{ systemd_journald_ttypath }}
+{% else %}
 #TTYPath=/dev/console
+{% endif $}
+{% if systemd_journald_maxlevelstore is defined %}
+MaxLevelStore={{ systemd_journald_maxlevelstore }}
+{% else %}
 #MaxLevelStore=debug
+{% endif $}
+{% if systemd_journald_maxlevelsyslog is defined %}
+MaxLevelSyslog={{ systemd_journald_maxlevelsyslog }}
+{% else %}
 #MaxLevelSyslog=debug
+{% endif $}
+{% if systemd_journald_maxlevelkmsg is defined %}
+MaxLevelKMsg={{ systemd_journald_maxlevelkmsg }}
+{% else %}
 #MaxLevelKMsg=notice
+{% endif $}
+{% if systemd_journald_maxlevelconsole is defined %}
+MaxLevelConsole={{ systemd_journald_maxlevelconsole }}
+{% else %}
 #MaxLevelConsole=info
+{% endif $}
+{% if systemd_journald_maxlevelwall is defined %}
+MaxLevelWall={{ systemd_journald_maxlevelwall }}
+{% else %}
 #MaxLevelWall=emerg
+{% endif $}
+{% if systemd_journald_linemax is defined %}
+LineMax={{ systemd_journald_linemax }}
+{% else %}
 #LineMax=48K
+{% endif $}
+{% if systemd_journald_readkmsg is defined %}
+ReadKMsg={{ systemd_journald_readkmsg }}
+{% else %}
 #ReadKMsg=yes
+{% endif $}
+{% if systemd_journald_audit is defined %}
+Audit={{ systemd_journald_audit }}
+{% else %}
 #Audit=yes
+{% endif $}


### PR DESCRIPTION
journald.conf.j2 now includes an optional role variable for each parameter
included with journald.  Additionally, I have added the configuration
file preamble included with the latest upstream journald release.

The templated file also now includes the {{ ansible_managed }}
standard heading.

Lastly, the README for the role was updated to cover this change.

fixes #2