### PR TITLE
generalize package install task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 
 - name: install systemd
-  pacman:
+  ansible.builtin.package:
     name: systemd
     state: present
 
 - name: configure systemd-journald
-  template:
+  ansible.builtin.template:
     src: journald.conf.j2
     dest: /etc/systemd/journald.conf
     owner: root


### PR DESCRIPTION
The package declaration ansible.builtin.package provides a simple
abstraction from distribution-specific calls for simple package
operations such as the installation of systemd.

fixes #6